### PR TITLE
[rpc] Allow file discovery and such

### DIFF
--- a/rpc/client.py
+++ b/rpc/client.py
@@ -1,4 +1,8 @@
+from os import fdopen
+from sys import argv, stdout
 import xmlrpc.client
 
+prog, subcmd, *args = argv  # dispatch the command
 proxy = xmlrpc.client.ServerProxy("http://localhost:8000/")
-with open("logo.png", "wb") as handle: handle.write(proxy.logo().data)
+out = fdopen(stdout.fileno(), 'wb')  # no we don't have to close it manually
+out.write(getattr(proxy, subcmd)(*args).data)

--- a/rpc/server.py
+++ b/rpc/server.py
@@ -1,10 +1,28 @@
+from os import walk
+from os.path import abspath, join
 from pathlib import Path
+from sys import argv
 from xmlrpc.client import Binary
 from xmlrpc.server import SimpleXMLRPCServer
 
-path = Path(__file__).parent.parent / 'logo-usth-pa3-01.png'
-with open(path, 'rb') as f: logo = Binary(f.read())
+if len(argv) != 2:
+    print(f'usage: {argv[0]} DIR')
+    exit()
+prefix = abspath(argv[1])
+paths = [join(parent, filename)[len(prefix)+1:]
+         for parent, folders, files in walk(prefix)
+         for filename in files]
+path_str = ('\n'.join(paths) + '\n').encode()
+
+
+def cat(file):
+    """Return the file content if permitted."""
+    if file not in paths: raise FileNotFoundError
+    return Path(join(prefix, file)).read_bytes()
+
+
 server = SimpleXMLRPCServer(("localhost", 8000))
+server.register_function(lambda: path_str, 'ls')
+server.register_function(cat, 'cat')
 print("Listening on port 8000...")
-server.register_function(lambda: logo, 'logo')
 server.serve_forever()


### PR DESCRIPTION
Open as requested by dr dx last lecture.  Usage example:

```console
$ python server.py .. &
$ python client.py ls
...
$ python client.py cat logo-usth-pa3-01.png > logo.png
```